### PR TITLE
Add some clarity to nmcli to make skimming easier

### DIFF
--- a/eduroam/nmcli.md
+++ b/eduroam/nmcli.md
@@ -30,7 +30,7 @@ All commands starting with `$` can be used as your standard user. All commands u
 ```
 $ nmcli device show
 ```
->Check the one whose `GENERAL.TYPE` is `wifi`
+>Check the one whose `GENERAL.TYPE` is `wifi`. Most commonly, this is `wlan0` or `wlp5s0`.
 3. Open a terminal and use nmcli to create a new wifi connection on your wireless network interface that connects to the `eduroam` network:
 ```
 $ nmcli connection add type wifi ifname <your interface> con-name eduroamWiFi ssid eduroam

--- a/eduroam/nmcli.md
+++ b/eduroam/nmcli.md
@@ -32,18 +32,18 @@ $ nmcli
 ```
 3. Open a terminal and use nmcli to create a new wifi connection on your wireless network interface that connects to the `eduroam` network:
 ```
-$ nmcli connection add type wifi ifname <your interface> con-name <connection name> ssid eduroam
+$ nmcli connection add type wifi ifname <your interface> con-name eduroamWiFi ssid eduroam
 ```
 4. then navigate to the NetworkManager/`nmcli` configuration directory:
 ```
 # cd /etc/NetworkManager/system-connections/
 ```
-5. Open the `eduroam.nmconnection` file in the editor of your choice *as root*. If you do not open it as root, the changes will not be saved.
+5. Open the `eduroamWiFi.nmconnection` file in the editor of your choice *as root*. If you do not open it as root, the changes will not be saved.
 
 6. Edit the file so that it contains the following lines. The file will contain most of these lines already. The `uuid` field will already be filled in, do not edit this field.
 ```
 [connection]
-id=<connection name>
+id=eduroamWiFi
 uuid=<generated UUID, don't edit this>
 type=wifi
 interface-name=<your interface>
@@ -79,7 +79,7 @@ method=auto
 
 7. Run the following command to activate the connection:
 ```
-# nmcli conection up <connection name>
+# nmcli conection up eduroamWiFi
 ```
 This tells `nmcli` that you want to bring up the network using the configuration that you created in the previous step.
 

--- a/eduroam/nmcli.md
+++ b/eduroam/nmcli.md
@@ -28,8 +28,9 @@ All commands starting with `$` can be used as your standard user. All commands u
 
 2. Grab the name of the wireless network interface  that you want to use for this connection. You will need this throughout this setup process. You can list all network interfaces by running the command:
 ```
-$ nmcli
+$ nmcli device show
 ```
+>Check the one whose `GENERAL.TYPE` is `wifi`
 3. Open a terminal and use nmcli to create a new wifi connection on your wireless network interface that connects to the `eduroam` network:
 ```
 $ nmcli connection add type wifi ifname <your interface> con-name eduroamWiFi ssid eduroam

--- a/eduroam/nmcli.md
+++ b/eduroam/nmcli.md
@@ -37,9 +37,9 @@ $ nmcli connection add type wifi ifname <your interface> con-name eduroamWiFi ss
 ```
 4. Open the `eduroamWiFi.nmconnection` file in the editor of your choice *as root*. If you do not open it as root, the changes will not be saved.
 ```
-# vim /etc/NetworkManager/system-connections/eduroamWiFi.nmconnection
+# nano /etc/NetworkManager/system-connections/eduroamWiFi.nmconnection
 ```
->Substitute `vim` for editor of choice
+>Substitute `nano` for editor of choice
 5. Edit the file so that it contains the following lines. The file will contain most of these lines already. The `uuid` field will already be filled in, **do not edit this field**.
 ```
 [connection]

--- a/eduroam/nmcli.md
+++ b/eduroam/nmcli.md
@@ -61,12 +61,12 @@ auth-alg=open
 key-mgmt=wpa-eap
 
 [802-1x]
-ca-cert=location/of/ritCACert
-client-cert=location/of/p12PrivateKey
+ca-cert=location/of/ritCACert.cer
+client-cert=location/of/p12PrivateKey.p12
 domain-suffix-match=radius.rit.edu
 eap=tls;
 identity=abc1234@rit.edu
-private-key=location/of/p12PrivateKey
+private-key=location/of/p12PrivateKey.p12
 private-key-password=<your private key password>
 
 [ipv4]

--- a/eduroam/nmcli.md
+++ b/eduroam/nmcli.md
@@ -42,7 +42,7 @@ $ nmcli connection add type wifi ifname <your interface> con-name eduroamWiFi ss
 >Plain sudo will not work; you must be the root user. This can be done with: `sudo su`
 5. Open the `eduroamWiFi.nmconnection` file in the editor of your choice *as root*. If you do not open it as root, the changes will not be saved.
 
-6. Edit the file so that it contains the following lines. The file will contain most of these lines already. The `uuid` field will already be filled in, do not edit this field.
+6. Edit the file so that it contains the following lines. The file will contain most of these lines already. The `uuid` field will already be filled in, **do not edit this field**.
 ```
 [connection]
 id=eduroamWiFi

--- a/eduroam/nmcli.md
+++ b/eduroam/nmcli.md
@@ -38,6 +38,7 @@ $ nmcli connection add type wifi ifname <your interface> con-name eduroamWiFi ss
 ```
 # cd /etc/NetworkManager/system-connections/
 ```
+>Plain sudo will not work; you must be the root user. This can be done with: `sudo su`
 5. Open the `eduroamWiFi.nmconnection` file in the editor of your choice *as root*. If you do not open it as root, the changes will not be saved.
 
 6. Edit the file so that it contains the following lines. The file will contain most of these lines already. The `uuid` field will already be filled in, do not edit this field.

--- a/eduroam/nmcli.md
+++ b/eduroam/nmcli.md
@@ -35,14 +35,12 @@ $ nmcli device show
 ```
 $ nmcli connection add type wifi ifname <your interface> con-name eduroamWiFi ssid eduroam
 ```
-4. then navigate to the NetworkManager/`nmcli` configuration directory:
+4. Open the `eduroamWiFi.nmconnection` file in the editor of your choice *as root*. If you do not open it as root, the changes will not be saved.
 ```
-# cd /etc/NetworkManager/system-connections/
+# vim /etc/NetworkManager/system-connections/eduroamWiFi.nmconnection
 ```
->Plain sudo will not work; you must be the root user. This can be done with: `sudo su`
-5. Open the `eduroamWiFi.nmconnection` file in the editor of your choice *as root*. If you do not open it as root, the changes will not be saved.
-
-6. Edit the file so that it contains the following lines. The file will contain most of these lines already. The `uuid` field will already be filled in, **do not edit this field**.
+>Substitute `vim` for editor of choice
+5. Edit the file so that it contains the following lines. The file will contain most of these lines already. The `uuid` field will already be filled in, **do not edit this field**.
 ```
 [connection]
 id=eduroamWiFi


### PR DESCRIPTION
I've used this guide fro connecting to WiFI at RIT. However, I was rushing to set the wifi up and skimmed over some crucial instructions.

My fixes modify nmcli.md to make it easier for fellow skimmers like myself to get to the important commands and content.