### PR TITLE
Added excluded files to config.yml so they don't get deployed

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -12,5 +12,10 @@ githubURL: https://github.com/RITlug/wiki
 plugins:
 - jekyll-remote-theme # add this line to the plugins list if you already have one
 
+exclude:
+  - start_devel_env.sh
+  - README.md
+  - Gemfile
+  - Gemfile.lock
 
 markdown: CommonMarkGhPages


### PR DESCRIPTION
I noticed some things get deployed that probably shouldn't be deployed.  For example, if one goes to http://wiki.ritlug.com/start_devel_env.sh , the shell script gets downloaded.

While I don't _think_ we need to explicitly exclude the Gemfile and the lock file, since that doesn't appear to be deployed, it doesn't hurt adding it to the excludes.

I didn't exclude License.txt since that doesn't matter if that gets uploaded or not (and could be useful).  I also didn't include Contributing.md; I feel like that should become an actual wiki page?